### PR TITLE
change log_configuration to logConfiguration in the container definition

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -61,7 +61,7 @@ resource "aws_ecs_task_definition" "Task" {
         }
       ],
 
-      log_configuration = [
+      logConfiguration = [
         {
           logDriver : "awslogs",
           options : {


### PR DESCRIPTION
The terraform container definition uses the container definition as-is as defined by the AWS Developer guide
"log_configuration" was ignored and wasn't included in the final task definition on ECS

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_task_definition#container_definitions
https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ContainerDefinition.html